### PR TITLE
fix(regexp): improve combine error message

### DIFF
--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -32,7 +32,8 @@ export function concat(args: (string | RegExp)[], flags?: string): RegExp {
             const currentFlags = c.flags.split("").sort().join("");
             if (foundRegExp) {
                 if (prevFlags !== currentFlags) {
-                    throw new Error(`combining different flags ${prevFlags} and ${currentFlags}`);
+                    throw new Error(`combining different flags ${prevFlags} and ${currentFlags}.
+The pattern ${c} has different flag with other patterns.`);
                 }
             }
             prevFlags = currentFlags;
@@ -56,7 +57,8 @@ export function combine(args: (string | RegExp)[], flags?: string): RegExp {
             const currentFlags = arg.flags.split("").sort().join("");
             if (foundRegExp) {
                 if (prevFlags !== currentFlags) {
-                    throw new Error(`combining different flags ${prevFlags} and ${currentFlags}`);
+                    throw new Error(`combining different flags ${prevFlags} and ${currentFlags}.
+The pattern ${arg} has different flag with other patterns.`);
                 }
             }
             prevFlags = currentFlags;

--- a/test/utils/regexpSpec.ts
+++ b/test/utils/regexpSpec.ts
@@ -79,6 +79,8 @@ describe("regexp", () => {
             try {
                 concat([/Hello/g, /TypeScript/im]);
             } catch (e) {
+                assert.strictEqual(e.message, `combining different flags g and im.
+The pattern /TypeScript/im has different flag with other patterns.`);
                 return;
             }
             assert.fail("spec succeed unexpectedly");
@@ -126,6 +128,8 @@ describe("regexp", () => {
             try {
                 combine([/Hello/g, /TypeScript/im]);
             } catch (e) {
+                assert.strictEqual(e.message, `combining different flags g and im.
+The pattern /TypeScript/im has different flag with other patterns.`);
                 return;
             }
             assert.fail("spec succeed unexpectedly");


### PR DESCRIPTION
flagが異なる時のエラーメッセージに実際に異なるパターンを出すようにしました。

例えば次のようなルールを設定していた場合のエラーメッセージが改善されると思います。
(flagだけが異なる場所を見つけるのが大変そうでした)

```yml
  - expected: タスク自動化ツール
    patterns:
      - タスクランナー
      - タスク管理ツール
      - /Task Runner/i
```

## Before

> combining different flags gmu and gimu

## After

> combining different flags gmu and gimu.
>The pattern /Task Runner/gimu has different flag with other patterns.

本当はprevPatternを出せると良かったのですがそのデータがなかったので、とりあえず異なるパターンの部分だけはでるようにしました。