### PR TITLE
refactor(regexp): remove unnecessary unicode flag runtime detection

### DIFF
--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -4,15 +4,6 @@ const hankakuAlphaNum = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012
 const zenkakuAlphaNum =
     "ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ０１２３４５６７８９";
 
-export const supportRegExpUnicodeFlag = (() => {
-    try {
-        new RegExp("", "u");
-        return true;
-    } catch (e) {
-        return false;
-    }
-})();
-
 // http://www.tamasoft.co.jp/ja/general-info/unicode.html
 export const jpHira = /[ぁ-ゖ]/;
 export const jpKana = /[ァ-ヺ]/;
@@ -117,10 +108,7 @@ export function spreadAlphaNum(str: string): RegExp {
 }
 
 export function addDefaultFlags(regexp: RegExp) {
-    let flags = "gm";
-    if (supportRegExpUnicodeFlag) {
-        flags += "u";
-    }
+    let flags = "gmu";
     if (regexp.ignoreCase) {
         flags += "i";
     }

--- a/test/utils/regexpSpec.ts
+++ b/test/utils/regexpSpec.ts
@@ -14,7 +14,6 @@ import {
     addDefaultFlags,
     escapeSpecialChars,
     collectAll,
-    supportRegExpUnicodeFlag,
 } from "../../lib/utils/regexp";
 
 describe("regexp", () => {
@@ -209,11 +208,7 @@ The pattern /TypeScript/im has different flag with other patterns.`);
             expect(regexp.global).toBe(true);
             expect(regexp.ignoreCase).toBe(false);
             expect(regexp.multiline).toBe(true);
-            if (supportRegExpUnicodeFlag) {
-                expect(regexp.unicode).toBe(true);
-            } else {
-                expect(regexp.unicode).toBeUndefined();
-            }
+            expect(regexp.unicode).toBe(true);
         });
         it("add g flags and keep i flag", () => {
             const regexp = addDefaultFlags(/hello/i);
@@ -222,11 +217,7 @@ The pattern /TypeScript/im has different flag with other patterns.`);
             expect(regexp.global).toBe(true);
             expect(regexp.ignoreCase).toBe(true);
             expect(regexp.multiline).toBe(true);
-            if (supportRegExpUnicodeFlag) {
-                expect(regexp.unicode).toBe(true);
-            } else {
-                expect(regexp.unicode).toBeUndefined();
-            }
+            expect(regexp.unicode).toBe(true);
         });
     });
 


### PR DESCRIPTION
## 概要

lib/utils/regexp.tsでunicodeフラグの有無をチェックする`supportRegExpUnicodeFlag`を削除し、`addDefaultFlags()`でデフォルトフラグを`gmu`にするようにした。

## 背景

これまでのコードでは、`u`フラグが使えるかのチェックを検出するフラグを用意していた。

https://github.com/prh/prh/blob/b6c16fe1286bef7563c1db482721889db27585ac/lib/utils/regexp.ts#L7-L14

そこで検出に使われていたのは`u`フラグだが、これはES2015で導入されたもので、JSエンジンでの対応も問題ない（Node.JS 10+）ため、現在は不要と判断

## 補足

package.jsonではNode.js 22+、tsconfig.jsonはes2020となっているので、それ相当の機能をベースにしてよいだろうとの判断です。