### PR TITLE
feat(regexp): エスケープ文字の円記号をバックスラッシュに修正し、1パスで置き換えるように効率化

### DIFF
--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -20,7 +20,7 @@ export const jpKana = /[ァ-ヺ]/;
 export const jpKanji = /(?:[々〇〻\u3400-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF])/;
 export const jpChar = combine([jpHira, jpKana, jpKanji]);
 
-const regexpSpecialChars = "¥*+.?{}()[]^$-|/".split("");
+const regexpSpecialChars = "\\*+.?{}()[]^$-|/".split("");
 
 export function concat(args: (string | RegExp)[], flags?: string): RegExp {
     let prevFlags = flags || "";

--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -20,8 +20,6 @@ export const jpKana = /[ァ-ヺ]/;
 export const jpKanji = /(?:[々〇〻\u3400-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF])/;
 export const jpChar = combine([jpHira, jpKana, jpKanji]);
 
-const regexpSpecialChars = "\\*+.?{}()[]^$-|/".split("");
-
 export function concat(args: (string | RegExp)[], flags?: string): RegExp {
     let prevFlags = flags || "";
     let foundRegExp = false;
@@ -127,11 +125,10 @@ export function addDefaultFlags(regexp: RegExp) {
     return new RegExp(regexp.source, flags);
 }
 
+// Note: Node.js v24がターゲット下限になったらRegExp.escape()に置き換えられる
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
 export function escapeSpecialChars(str: string): string {
-    regexpSpecialChars.forEach((char) => {
-        str = str.replace(new RegExp(`\\${char}`, "g"), `\\${char}`);
-    });
-    return str;
+    return str.replace(/[\\*+.?{}()|^$[\]/-]/g, "\\$&");
 }
 
 export function collectAll(regexp: RegExp, src: string) {

--- a/test/utils/regexpSpec.ts
+++ b/test/utils/regexpSpec.ts
@@ -237,9 +237,9 @@ The pattern /TypeScript/im has different flag with other patterns.`);
             expect(result).toBe("\\/\\(\\?!S\\)ML\\/");
         });
         it("replace special characters 2", () => {
-            const result = escapeSpecialChars("¥*+.?{}()[]^$-|/");
+            const result = escapeSpecialChars("\\*+.?{}()[]^$-|/");
 
-            expect(result).toBe("\\¥\\*\\+\\.\\?\\{\\}\\(\\)\\[\\]\\^\\$\\-\\|\\/");
+            expect(result).toBe("\\\\\\*\\+\\.\\?\\{\\}\\(\\)\\[\\]\\^\\$\\-\\|\\/");
         });
     });
 


### PR DESCRIPTION
## 概要

* 正規表現のエスケープすべき文字に円記号が入ってたのでバックスラッシュに修正
* `escapeSpecialChars()`の内部処理を簡素化し、将来的な`RegExp.escap()`の導入に対するコメントも追加

fixes #85