### PR TITLE
feat(regexp): complete equals() flag comparison

### DIFF
--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -151,6 +151,15 @@ export function equals(a: RegExp, b: RegExp) {
     if (a.multiline !== b.multiline) {
         return false;
     }
+    if (a.unicode !== b.unicode) {
+        return false;
+    }
+    if (a.sticky !== b.sticky) {
+        return false;
+    }
+    if (a.dotAll !== b.dotAll) {
+        return false;
+    }
 
     return true;
 }

--- a/test/utils/regexpSpec.ts
+++ b/test/utils/regexpSpec.ts
@@ -267,11 +267,17 @@ The pattern /TypeScript/im has different flag with other patterns.`);
             expect(equals(/a/i, /a/i)).toBe(true);
             expect(equals(/a/g, /a/g)).toBe(true);
             expect(equals(/a/m, /a/m)).toBe(true);
+            expect(equals(/a/u, /a/u)).toBe(true);
+            expect(equals(/a/y, /a/y)).toBe(true);
+            expect(equals(/a/s, /a/s)).toBe(true);
 
             expect(equals(/a/, /b/)).toBe(false);
             expect(equals(/a/i, /a/)).toBe(false);
             expect(equals(/a/g, /a/)).toBe(false);
             expect(equals(/a/m, /a/)).toBe(false);
+            expect(equals(/a/u, /a/)).toBe(false);
+            expect(equals(/a/y, /a/)).toBe(false);
+            expect(equals(/a/s, /a/)).toBe(false);
         });
     });
 });


### PR DESCRIPTION
## 要約
prhが登場して以降に仕様と実装に追加されたRegExpオブジェクトのunicode, sticky, dotAllのフラグをregexp.tsの`equals()`関数に追加し、未知のフラグで異なってもtrueにならないように修正します。

## Summary
- Add missing `unicode`, `sticky`, and `dotAll` flag checks to `equals()` function in `lib/utils/regexp.ts`
- These flags were not being compared, causing RegExps with identical sources but different flags to be incorrectly reported as equal
- Add corresponding test cases in `test/utils/regexpSpec.ts`

## Details
The `equals()` function now performs complete equality checks by comparing all standard RegExp flags: `global`, `ignoreCase`, `multiline`, `unicode`, `sticky`, and `dotAll`.

These flags (`unicode` in ES2015, `sticky` in ES2015, `dotAll` in ES2018) were introduced after prh was originally created, which explains why they were missing from the original implementation.

## Verification
- `npm run build` passes
- All 78 code-level tests pass (29 regexp-specific tests including new cases)
- 4 pre-existing submodule-related test failures are unrelated