### PR TITLE
refactor(regexp): replace collectAll() with native matchAll()

### DIFF
--- a/lib/changeset/index.ts
+++ b/lib/changeset/index.ts
@@ -1,12 +1,10 @@
-import { collectAll } from "../utils/regexp";
 import { Diff } from "./diff";
 import { ChangeSet } from "./changeset";
 
 export { ChangeSet, Diff };
 
 export function makeChangeSet(filePath: string, content: string, pattern: RegExp, expected?: string): ChangeSet {
-    pattern.lastIndex = 0;
-    const resultList = collectAll(pattern, content);
+    const resultList = [...content.matchAll(pattern)];
     const diffs = resultList.map((matches) => new Diff({ pattern, expected, index: matches.index, matches }));
     return new ChangeSet({ filePath, content, diffs });
 }

--- a/lib/rule.ts
+++ b/lib/rule.ts
@@ -1,4 +1,4 @@
-import { spreadAlphaNum, addBoundary, addDefaultFlags, parseRegExpString, escapeSpecialChars, combine, collectAll } from "./utils/regexp";
+import { spreadAlphaNum, addBoundary, addDefaultFlags, parseRegExpString, escapeSpecialChars, combine } from "./utils/regexp";
 
 import { Options } from "./options";
 import { RuleSpec } from "./ruleSpec";
@@ -131,7 +131,7 @@ export class Rule {
 
     applyRule(content: string): Diff[] {
         this.reset();
-        const resultList = collectAll(this.pattern, content);
+        const resultList = [...content.matchAll(this.pattern)];
         return resultList
             .map((matches) => {
                 // JavaScriptでの正規表現では /(?<!記|大)事/ のような書き方ができない

--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -119,25 +119,6 @@ export function escapeSpecialChars(str: string): string {
     return str.replace(/[\\*+.?{}()|^$[\]/-]/g, "\\$&");
 }
 
-export function collectAll(regexp: RegExp, src: string) {
-    if (!regexp.global) {
-        throw new Error("g flag is required");
-    }
-    if (!regexp.source) {
-        throw new Error("source is required");
-    }
-    const resultList: RegExpExecArray[] = [];
-    let result: RegExpExecArray | null;
-    do {
-        result = regexp.exec(src);
-        if (result) {
-            resultList.push(result);
-        }
-    } while (result);
-
-    return resultList;
-}
-
 export function equals(a: RegExp, b: RegExp) {
     if (a.source !== b.source) {
         return false;

--- a/test/changeset/changesetSpec.ts
+++ b/test/changeset/changesetSpec.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from "vitest";
 
-import { collectAll } from "../../lib/utils/regexp";
-
 import { makeChangeSet, ChangeSet } from "../../lib/changeset";
 import { Diff } from "../../lib/changeset/diff";
 
@@ -13,7 +11,7 @@ describe("ChangeSet", () => {
             {
                 const pattern = /例え/g;
                 const expected = "たとえ";
-                const extraDiffs = collectAll(pattern, base).map((matches) => {
+                const extraDiffs = [...base.matchAll(pattern)].map((matches) => {
                     return new Diff({ pattern, expected, index: matches.index, matches });
                 });
                 diffs = [...diffs, ...extraDiffs];
@@ -21,7 +19,7 @@ describe("ChangeSet", () => {
             {
                 const pattern = /例えば/g;
                 const expected = "たとえば";
-                const extraDiffs = collectAll(pattern, base).map((matches) => {
+                const extraDiffs = [...base.matchAll(pattern)].map((matches) => {
                     return new Diff({ pattern, expected, index: matches.index, matches });
                 });
                 diffs = [...diffs, ...extraDiffs];
@@ -36,7 +34,7 @@ describe("ChangeSet", () => {
             {
                 const pattern = /AB/g;
                 const expected = "ab";
-                const extraDiffs = collectAll(pattern, base).map((matches) => {
+                const extraDiffs = [...base.matchAll(pattern)].map((matches) => {
                     return new Diff({ pattern, expected, index: matches.index, matches });
                 });
                 diffs = [...diffs, ...extraDiffs];
@@ -44,7 +42,7 @@ describe("ChangeSet", () => {
             {
                 const pattern = /BC/g;
                 const expected = "bc";
-                const extraDiffs = collectAll(pattern, base).map((matches) => {
+                const extraDiffs = [...base.matchAll(pattern)].map((matches) => {
                     return new Diff({ pattern, expected, index: matches.index, matches });
                 });
                 diffs = [...diffs, ...extraDiffs];
@@ -59,7 +57,7 @@ describe("ChangeSet", () => {
             const pattern = /Webだー*/g;
             const expected = "Webさ";
             const base = "今日の晩御飯はWebだーーーーーーー！そしておかずもWebだ！";
-            const diffs = collectAll(pattern, base).map((matches) => {
+            const diffs = [...base.matchAll(pattern)].map((matches) => {
                 return new Diff({ pattern, expected, index: matches.index, matches });
             });
             const changeSets = new ChangeSet({ content: base, diffs });
@@ -70,7 +68,7 @@ describe("ChangeSet", () => {
             const pattern = /Web/g;
             const expected = "ウェッブ";
             const base = "今日の晩御飯はWebだ！そしておかずもWebだ！";
-            const diffs = collectAll(pattern, base).map((matches) => {
+            const diffs = [...base.matchAll(pattern)].map((matches) => {
                 return new Diff({ pattern, expected, index: matches.index, matches });
             });
             const changeSets = new ChangeSet({ content: base, diffs });
@@ -81,7 +79,7 @@ describe("ChangeSet", () => {
             const pattern = /(博多)の(潮)/g;
             const expected = "伯方($1ではない)の塩($2ではない)";
             const base = "白いご飯と博多の潮！";
-            const diffs = collectAll(pattern, base).map((matches) => {
+            const diffs = [...base.matchAll(pattern)].map((matches) => {
                 return new Diff({ pattern, expected, index: matches.index, matches });
             });
             const changeSets = new ChangeSet({ content: base, diffs });
@@ -92,10 +90,10 @@ describe("ChangeSet", () => {
             const patternA = /Web/gi;
             const patternB = /火/gi;
             const base = "ある火のWEBと、とある火のwebの話";
-            const diffA = collectAll(patternA, base).map((matches) => {
+            const diffA = [...base.matchAll(patternA)].map((matches) => {
                 return new Diff({ pattern: patternA, expected: "Web", index: matches.index, matches });
             });
-            const diffB = collectAll(patternB, base).map((matches) => {
+            const diffB = [...base.matchAll(patternB)].map((matches) => {
                 return new Diff({ pattern: patternB, expected: "日", index: matches.index, matches });
             });
             const changeSetsA = new ChangeSet({ content: base, diffs: diffA });

--- a/test/utils/regexpSpec.ts
+++ b/test/utils/regexpSpec.ts
@@ -13,7 +13,6 @@ import {
     spreadAlphaNum,
     addDefaultFlags,
     escapeSpecialChars,
-    collectAll,
 } from "../../lib/utils/regexp";
 
 describe("regexp", () => {
@@ -234,10 +233,10 @@ The pattern /TypeScript/im has different flag with other patterns.`);
         });
     });
 
-    describe("collectAll", () => {
+    describe("matchAll", () => {
         it("collect all matching place", () => {
             const str = "今日まで広くC言語は使われてきました。\nしかし、ここに至りC++やC#などが登場し隆盛を極め…";
-            const result = collectAll(/(C(\+\+|#)?)/g, str);
+            const result = [...str.matchAll(/(C(\+\+|#)?)/g)];
 
             expect(result.length).toBe(3);
 


### PR DESCRIPTION
## 要約

regexp.tsに`collectAll()`という、ある正規表現にマッチする結果をすべて取得するユーティリティ関数があるのですが、同等のことをする[`String.prototype.matchAll()`というメソッド](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll)がESに追加されたので、それに置き換えます。
ES2020で追加され、すでに実装されても久しいこと、このプロジェクトのターゲットが現在es2020になっているようなので大丈夫かと思っています。

## Summary

- Replace custom `collectAll()` function with native `String.prototype.matchAll()`
- Available since ES2020 (the project's target)
- Remove duplicated functionality and simplify code

## Changes

- **lib/utils/regexp.ts**: Remove `collectAll()` function (19 lines)
- **lib/rule.ts**: Use `[...content.matchAll(this.pattern)]` instead of `collectAll()`
- **lib/changeset/index.ts**: Use `[...content.matchAll(pattern)]` instead of `collectAll()`
- **test/utils/regexpSpec.ts**: Update test to use `matchAll()`
- **test/changeset/changesetSpec.ts**: Update all tests to use `matchAll()`

## Verification

- `npm run build` passes
- All 58 relevant tests pass (4 pre-existing submodule-related failures unrelated)
- No behavior change — `matchAll()` produces equivalent results

## Benefits

- Removes ~20 lines of custom code that duplicates native functionality
- `matchAll()` returns an iterator (more memory-efficient for large inputs)
- Cleaner, more idiomatic JavaScript
- No `lastIndex` management needed