### PR TITLE
feat(regexp): update parseRegExpString to support modern regex flags (u, s)

### DIFF
--- a/_myakura/investigations/regexp-bugs.md
+++ b/_myakura/investigations/regexp-bugs.md
@@ -1,0 +1,115 @@
+# Bug Investigation: `lib/utils/regexp.ts`
+
+**Last updated:** 2026-04-27
+**Status:** INVESTIGATION COMPLETE — tasks split into [Plan 08](../plans/08-fix-escapeSpecialChars-hyphen/) and [Plan 09](../plans/09-remove-dead-flag-sort/)
+
+## Overview
+
+This document investigates bugs and correctness issues in `lib/utils/regexp.ts`, separate from the [RegExp Modernization](../investigations/regexp-modernization.md) effort which focuses on replacing obsolete workarounds with modern JS features.
+
+Issues found have been split into implementation plans:
+- [Plan 08: Fix `escapeSpecialChars()` hyphen & brackets](../plans/08-fix-escapeSpecialChars-hyphen/) — high severity
+- [Plan 09: Remove dead flag sort code](../plans/09-remove-dead-flag-sort/) — low severity
+
+---
+
+## Issues Found
+
+### Issue #34: Hyphen Escaping Causes Invalid Regex with `u` Flag (HIGH SEVERITY)
+
+**File:** `lib/utils/regexp.ts:119`
+**Status:** Confirmed bug → [Plan 08 created](../plans/08-fix-escapeSpecialChars-hyphen/)
+
+The `escapeSpecialChars()` function escapes `-` with `\-`. Outside character classes, `-` is literal and doesn't need escaping. With the `u` flag (which prh uses via `addDefaultFlags()`), `\-` is an invalid escape sequence.
+
+**Reproduction:**
+```javascript
+const escape = (str) => str.replace(/[\\*+.?{}()|^$[\]/-]/g, "\\$&");
+new RegExp(escape("R-18"), "gmu"); // Error: Invalid escape sequence
+new RegExp(escape("[a-z]"), "gmu"); // Error: Invalid escape sequence
+```
+
+**Impact:** Any pattern containing `-` or `[` `]` will crash when converted to regex with the `u` flag.
+
+---
+
+### Issue #34 (revisited): Square Bracket Escaping (HIGH SEVERITY)
+
+**File:** `lib/utils/regexp.ts:119`
+**Status:** Same as above → [Plan 08](../plans/08-fix-escapeSpecialChars-hyphen/)
+
+The character class `[\\*+.?{}()|^$[\]/-]` includes `]` but has it in the wrong position. In a character class, `]` must be first or properly escaped.
+
+---
+
+### Issue: `equals()` Missing Flags (LOW SEVERITY)
+
+**File:** `lib/utils/regexp.ts:141-155`
+**Status:** Tracked in [ROADMAP as Pattern 02](../plans/02-complete-equals-flag-check/)
+
+The `equals()` function only checks `global`, `ignoreCase`, and `multiline` flags. It misses `unicode`, `sticky`, and `dotAll`.
+
+```typescript
+export function equals(a: RegExp, b: RegExp) {
+    // ... checks source, global, ignoreCase, multiline
+    return true; // missing unicode, sticky, dotAll
+}
+```
+
+This is tracked as [Pattern 02 in the ROADMAP](../plans/02-complete-equals-flag-check/).
+
+---
+
+### Issue: `parseRegExpString()` Drops `u` and `s` Flags (MEDIUM SEVERITY)
+
+**File:** `lib/utils/regexp.ts:1`
+**Status:** FIXED — PR #93 opened
+
+The regex `/^\/(.*)\/([gimy]*)$/` only recognizes `g`, `i`, `m`, `y` flags. `u` and `s` are silently dropped.
+
+```typescript
+const regexpRegexp = /^\/(.*)\/([gimsuy]*)$/;  // Fixed
+```
+
+If a user writes `/pattern/us` in YAML, the `u` and `s` flags would be lost. However, `addDefaultFlags()` adds `gmu` by default, so this may not manifest in practice for most cases.
+
+This was fixed in [Pattern 04 in the ROADMAP](../plans/04-update-parseRegExpString-flags/) — PR #93.
+
+---
+
+### Issue: Flag Sorting in `concat()` and `combine()` (LOW SEVERITY)
+
+**File:** `lib/utils/regexp.ts:21, 47`
+**Status:** → [Plan 09 created](../plans/09-remove-dead-flag-sort/)
+
+Dead code: `arg.flags.split("").sort()` is called but the result is discarded. Should be removed.
+
+### Issue: `concat()` Returns Empty Flags
+
+**File:** `lib/utils/regexp.ts:36`
+**Status:** NOT A BUG — `addDefaultFlags()` adds flags when needed
+
+When `concat()` is called with only strings, `foundRegExp` remains `false` and `prevFlags` is `""`. This returns a RegExp with no flags. But `addDefaultFlags()` is always called after `concat()` in practice, so this is not a problem.
+
+---
+
+## Issues Not in This File
+
+### Issue #32, #40: `$1` Reference in Combined Alternation
+
+**Files:** `lib/utils/regexp.ts:39-64` (`combine()`), `lib/changeset/diff.ts` (`replace()`)
+**Status:** Design issue, documented in [`issue-32.md`](issue-32.md) and [`issue-40.md`](issue-40.md)
+
+When `patterns` is an array, `combine()` creates alternation with each pattern's capture group. But `$1` in `expected` always refers to the first alternation's group.
+
+---
+
+## Summary
+
+| Bug | Severity | Status | Plan |
+|-----|----------|--------|------|
+| Hyphen/bracket escaping (`\-`) | High | Bug confirmed | [Plan 08](../plans/08-fix-escapeSpecialChars-hyphen/) |
+| `equals()` missing flags | Low | Known | [Pattern 02](../plans/02-complete-equals-flag-check/) — PR #91 |
+| `parseRegExpString` drops flags | Medium | FIXED | [Pattern 04](../plans/04-update-parseRegExpString-flags/) — PR #93 |
+| Flag sorting dead code | Low | Bug confirmed | [Plan 09](../plans/09-remove-dead-flag-sort/) |
+| `concat()` empty flags | — | Not a bug | N/A |

--- a/_myakura/investigations/regexp-modernization.md
+++ b/_myakura/investigations/regexp-modernization.md
@@ -1,0 +1,305 @@
+# RegExp Modernization Investigation
+
+**Last updated:** 2026-04-27
+**Status:** Patterns 01, 07 merged (PR #86, #87); Pattern 03 PR #92 opened; Pattern 06 done locally
+
+## Overview
+
+The prh codebase was written when JavaScript's RegExp support was significantly more limited. Several workarounds and manual implementations exist that can now be replaced with modern ECMAScript features, since the project targets **ES2020** (`tsconfig.json`).
+
+This investigation identifies 6 patterns that can be modernized, ordered by implementation difficulty (easiest first).
+
+---
+
+## 1. Remove `supportRegExpUnicodeFlag` Runtime Detection
+
+**File:** `lib/utils/regexp.ts:7-14`
+**Difficulty:** Trivial
+**Impact:** Low (cleanup)
+
+### Current Code
+
+```typescript
+export const supportRegExpUnicodeFlag = (() => {
+    try {
+        new RegExp("", "u");
+        return true;
+    } catch (e) {
+        return false;
+    }
+})();
+```
+
+Used in `addDefaultFlags()` (line 119-128):
+
+```typescript
+export function addDefaultFlags(regexp: RegExp) {
+    let flags = "gm";
+    if (supportRegExpUnicodeFlag) {
+        flags += "u";
+    }
+    if (regexp.ignoreCase) {
+        flags += "i";
+    }
+    return new RegExp(regexp.source, flags);
+}
+```
+
+### Problem
+
+The `u` flag was introduced in ES2015 and is universally supported in all modern JS engines. The project targets ES2020, making this runtime check completely unnecessary. It adds dead code and a conditional branch that always evaluates to `true`.
+
+### Solution
+
+Delete the IIFE entirely. Unconditionally use the `u` flag in `addDefaultFlags()`:
+
+```typescript
+export function addDefaultFlags(regexp: RegExp) {
+    let flags = "gmu";
+    if (regexp.ignoreCase) {
+        flags += "i";
+    }
+    return new RegExp(regexp.source, flags);
+}
+```
+
+---
+
+## 2. Complete `equals()` Flag Comparison
+
+**File:** `lib/utils/regexp.ts:156-171`
+**Difficulty:** Low
+**Impact:** Low (correctness fix)
+
+### Current Code
+
+```typescript
+export function equals(a: RegExp, b: RegExp) {
+    if (a.source !== b.source) {
+        return false;
+    }
+    if (a.global !== b.global) {
+        return false;
+    }
+    if (a.ignoreCase !== b.ignoreCase) {
+        return false;
+    }
+    if (a.multiline !== b.multiline) {
+        return false;
+    }
+    return true;
+}
+```
+
+### Problem
+
+Only checks `global`, `ignoreCase`, and `multiline` flags. Missing `unicode`, `sticky`, and `dotAll` — all standard since ES2015/ES2018. Two RegExps with identical sources but different `u` flags would incorrectly be reported as equal.
+
+### Solution
+
+Add checks for the missing flags:
+
+```typescript
+if (a.unicode !== b.unicode) {
+    return false;
+}
+if (a.sticky !== b.sticky) {
+    return false;
+}
+if (a.dotAll !== b.dotAll) {
+    return false;
+}
+```
+
+---
+
+## 3. Replace `collectAll()` with `String.prototype.matchAll()`
+
+**File:** `lib/utils/regexp.ts`
+**Difficulty:** Trivial
+**Impact:** Low (code simplification)
+**Status:** DONE — PR #92 merged
+
+### Problem
+
+The custom `collectAll()` function manually iterates over regex matches using `RegExp.exec()`. This duplicates native functionality available since ES2020 via `String.prototype.matchAll()`.
+
+### Solution (Implemented)
+
+- Removed `collectAll()` function entirely from `lib/utils/regexp.ts`
+- Updated `lib/rule.ts` to use `[...content.matchAll(this.pattern)]`
+- Updated `lib/changeset/index.ts` to use `[...content.matchAll(pattern)]`
+- Updated tests to use `matchAll()` directly
+
+This removes ~20 lines of custom code with no behavior change.
+
+---
+
+## 4. Update `parseRegExpString` to Support Modern Flags
+
+**File:** `lib/utils/regexp.ts:1`
+**Difficulty:** Low
+**Impact:** Medium (correctness for user-facing YAML)
+**Status:** DONE — PR #93 opened
+
+### Current Code
+
+```typescript
+const regexpRegexp = /^\/(.*)\/([gimsuy]*)$/;
+```
+
+### Problem
+
+Only captures `g`, `i`, `m`, `y` flags. Missing `u` and `s` (dotAll). If a user writes `/pattern/us` in their YAML config, the `u` and `s` flags would be silently dropped.
+
+### Solution (Implemented)
+
+Updated the flag capture regex to include `u` and `s` flags. Added tests for `u`, `s`, and combined modern flags.
+
+Note: `y` (sticky) is already included but rarely used. `d` (hasIndices, ES2022) and `v` (unicodeSets, ES2024) could be added later if needed.
+
+---
+
+## 5. Modernize `jpKanji` Surrogate Pairs
+
+**File:** `lib/utils/regexp.ts:20`
+**Difficulty:** Medium
+**Impact:** Medium (readability and correctness)
+
+### Current Code
+
+```typescript
+export const jpKanji = /(?:[々〇〻\u3400-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF])/;
+```
+
+### Problem
+
+Manually encodes surrogate pairs for CJK Unified Ideographs Extension B. This is hard to read, error-prone, and was necessary before the `u` flag was available. With the `u` flag, code point escapes can be used directly.
+
+### Solution
+
+Option A — Code point escapes with `u` flag:
+
+```typescript
+export const jpKanji = /(?:[々〇〻\u3400-\u9FFF\uF900-\uFAFF]|\u{20000}-\u{2A6DF}|\u{2F800}-\u{2FA1F})/u;
+```
+
+Option B — Unicode property escape (simplest but broader):
+
+```typescript
+export const jpKanji = /[\p{Script=Han}々〇〻]/u;
+```
+
+Option B may match more characters than the original (e.g., simplified Chinese Han characters), so Option A is safer for maintaining exact compatibility.
+
+---
+
+## 6. Deprecate `regexpMustEmpty` — Negative Lookbehind Substitute
+
+**Files:** `lib/rule.ts:14,58,137-148`, `lib/raw.ts:34`, `misc/prh.yml:74`
+**Difficulty:** Medium
+**Impact:** Non-breaking (deprecation warning only)
+
+### Current Code
+
+**`lib/rule.ts:137-148`:**
+
+```typescript
+// JavaScriptでの正規表現では /(?<!記|大)事/ のような書き方ができない
+// /(記|大)事/ で regexpMustEmpty $1 の場合、第一グループが空じゃないとマッチしない、というルールにして回避
+if (this.regexpMustEmpty) {
+    const match = /^\$([0-9]+)$/.exec(this.regexpMustEmpty);
+    if (match == null) {
+        throw new Error(`${this.expected} target failed. please use $1 format.`);
+    }
+    const index = parseInt(match[1], 10);
+    if (matches[index]) {
+        return null;
+    }
+}
+```
+
+**`lib/raw.ts:34`:**
+
+```typescript
+regexpMustEmpty?: string;
+```
+
+**`misc/prh.yml:74` (comment):**
+
+```yaml
+# 否定戻り先読みが欲しいがJSにはない… regexpMustEmptyで、特定のキャプチャグループが空であることを指定して代用とする
+```
+
+### Problem
+
+This entire feature exists as a workaround for JavaScript lacking negative lookbehind. ES2018 introduced variable-length negative lookbehind `(?<!...)`, making this workaround obsolete.
+
+Users currently write:
+
+```yaml
+pattern: /(記|大)事/
+regexpMustEmpty: $1
+```
+
+With native lookbehind, they can write:
+
+```yaml
+pattern: /(?<!記|大)事/
+```
+
+However, there are many existing YAML rule files using `regexpMustEmpty` in the wild (see [GitHub search](https://github.com/search?type=code&q=regexpMustEmpty+language%3AYAML&l=YAML)), so removal is not feasible.
+
+### Solution
+
+**Deprecation path:**
+
+- Keep the field and logic intact (no breaking changes)
+- Add a `console.warn()` when `regexpMustEmpty` is used
+- Update comments in `misc/prh.yml` to note that native lookbehind is preferred
+- Document the migration path in README
+
+```typescript
+if (this.regexpMustEmpty) {
+    console.warn(`regexpMustEmpty is deprecated. Use native negative lookbehind (?<!...) in your pattern instead.`);
+    const match = /^\$([0-9]+)$/.exec(this.regexpMustEmpty);
+    // ... rest unchanged
+}
+```
+
+### Affected Files
+
+| File           | Lines   | Change                  |
+| -------------- | ------- | ----------------------- |
+| `lib/rule.ts`  | 137-148 | Add deprecation warning |
+| `misc/prh.yml` | 74      | Update comment          |
+
+---
+
+## Summary
+
+- 01: Remove `supportRegExpUnicodeFlag`
+    - Trivial. 1 IIFE deleted, 1 function simplified — **DONE** (PR #86 merged)
+- 02: Complete `equals()` flag check
+    - Low. Add 3 flag comparisons — **DONE** (PR #91 opened)
+- 03: Replace `collectAll` with `matchAll`
+    - Trivial. 1 function → one-liner — **DONE** (PR #92 merged)
+- 04: Update `parseRegExpString` flags
+    - Low. 1 regex pattern update — **DONE** (PR #93 opened)
+- 05: Modernize `jpKanji` surrogate pairs
+    - Medium. Unicode range rewrite
+- 06: Remove `regexpMustEmpty`
+    - High. Removes field, interface, logic, comments
+
+| #   | Feature Used                  | ES Version    | Node |
+| --- | ----------------------------- | ------------- | ---- |
+| 01  | `u` flag                      | ES2015        | v10+ |
+| 02  | `unicode`, `sticky`, `dotAll` | ES2015/ES2018 | v10+ |
+| 03  | `String.matchAll()`           | ES2020        | v14+ | DONE (PR #92) |
+| 04  | `s` flag                      | ES2018        | v12+ |
+| 05  | `\u{...}` + `u` flag          | ES2015        | v10+ |
+| 06  | Negative lookbehind           | ES2018        | v10+ |
+
+All changes are enabled by the project's ES2020 target. Patterns 01-05 are non-breaking. Pattern 06 is a breaking change for users of `regexpMustEmpty` in their YAML rules.
+
+All features used here are available in every currently maintained Node.js LTS line (v20, v22, v24). No minimum version bump is required.

--- a/_myakura/plans/04-update-parseRegExpString-flags/issue.md
+++ b/_myakura/plans/04-update-parseRegExpString-flags/issue.md
@@ -1,0 +1,29 @@
+# Update `parseRegExpString` to Support Modern Flags
+
+**Last updated:** 2026-04-29
+**Status:** IMPLEMENTED (upstream PR #93)
+
+## Background
+
+The `parseRegExpString()` function parses user-written regexp literals from YAML config strings (e.g., `/pattern/gi`).
+
+## Problem
+
+The flag capture regex `/^\/(.*)\/([gimy]*)$/` only recognizes `g`, `i`, `m`, and `y` flags. It silently drops `u` (unicode) and `s` (dotAll) flags. If a user writes `/pattern/us` in their YAML config, those flags would be lost, potentially causing incorrect matching behavior.
+
+## Solution
+
+Update the flag capture regex to include `u` and `s`: `/^\/(.*)\/([gimsuy]*)$/`.
+
+## Changes
+
+- Update `regexpRegexp` constant in `lib/utils/regexp.ts` (line 1)
+- Add tests for `u`, `s`, and combined modern flags in `test/utils/regexpSpec.ts`
+
+## Migration
+
+None required. This is a bug fix — previously valid flags were silently dropped.
+
+## PR
+
+- Upstream PR #93: https://github.com/prh/prh/pull/93

--- a/_myakura/plans/ROADMAP.md
+++ b/_myakura/plans/ROADMAP.md
@@ -1,0 +1,66 @@
+# ROADMAP: RegExp Modernization
+
+**Last updated:** 2026-04-29
+**Status:** 6/9 patterns complete (01, 07 merged; 02 PR #91 opened; 03 PR #92 opened; 04 PR #93 opened; 06 done locally)
+
+## Overview
+
+Modernize regexp patterns and workarounds in prh that were written when JavaScript's RegExp support was limited. The project targets ES2020, making several workarounds obsolete.
+
+Ordered by implementation difficulty (easiest first) to help maintainers understand the problem space and review patches incrementally.
+
+---
+
+## Tasks
+
+- [x] [01: Remove `supportRegExpUnicodeFlag` runtime detection](01-remove-unicode-flag-detection/) — **IMPLEMENTED** (upstream PR #86, merged)
+- [x] [02: Complete `equals()` flag comparison](02-complete-equals-flag-check/) — **IMPLEMENTED** (upstream PR #91)
+- [x] [03: Replace `collectAll()` with `matchAll()`](03-replace-collectAll-with-matchAll/) — **IMPLEMENTED** (upstream PR #92)
+- [x] [04: Update `parseRegExpString` to support modern flags](04-update-parseRegExpString-flags/) — **IMPLEMENTED** (upstream PR #93)
+- [ ] [05: Modernize `jpKanji` surrogate pairs](05-modernize-jpKanji-surrogate-pairs/)
+- [ ] [06: Deprecate `regexpMustEmpty` workaround](06-remove-regexpMustEmpty/)
+- [x] [07: Fix `escapeSpecialChars()` yen sign](07-fix-escapeSpecialChars/) — **IMPLEMENTED** (upstream PR #87, merged)
+- [ ] [08: Fix `escapeSpecialChars()` hyphen & brackets](08-fix-escapeSpecialChars-hyphen/) — Issue #34
+- [ ] [09: Remove dead flag sort in `concat()` and `combine()`](09-remove-dead-flag-sort/)
+
+---
+
+## Dependencies
+
+```
+01 (unicode flag detection) ──┬── 05 (jpKanji surrogate pairs)
+                               └── 02 (equals flag check)
+03 (collectAll → matchAll) ── independent, upstream PR #92 opened
+04 (parseRegExpString flags) ── independent, PR #93 opened
+06 (regexpMustEmpty) ───────── independent
+02 (equals flag check) ─────── upstream PR #91 opened
+07 (escapeSpecialChars yen) ─── upstream PR #87 merged ✓
+08 (escapeSpecialChars hyphen) ── independent (follow-up to PR #87)
+09 (dead flag sort) ─────────── independent
+```
+
+## Impact Summary
+
+| #   | Difficulty | Breaking?        | Review Effort |
+| --- | ---------- | ---------------- | ------------- |
+| 01  | Trivial    | No               | Minimal       |
+| 02  | Low        | No               | Minimal       |
+| 03  | Trivial    | No               | Minimal       |
+| 04  | Low        | No               | Low           |
+| 05  | Medium     | No               | Moderate      |
+| 06  | Medium     | No (deprecation) | Low           |
+| 07  | Trivial    | No (bug fix)     | Minimal       |
+| 08  | Trivial    | No (bug fix)     | Minimal       |
+| 09  | Trivial    | No (cleanup)     | Minimal       |
+
+---
+
+## Notes
+
+- Tasks 01-05 are non-breaking internal cleanups
+- Task 06 (`regexpMustEmpty`) is a deprecation warning — the field and logic are kept for backward compatibility
+- Task 07 (`escapeSpecialChars`) fixed the yen sign — PR #87 merged
+- Task 08 (`escapeSpecialChars`) fixes hyphen and bracket escaping — Issue #34 (NOT fixed by PR #87)
+- Task 09 (`concat`/`combine`) removes dead flag sort code — cosmetic fix
+- Full investigation: [`../investigations/regexp-modernization.md`](../investigations/regexp-modernization.md)
+- Bug investigation: [`../investigations/regexp-bugs.md`](../investigations/regexp-bugs.md)

--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -1,4 +1,4 @@
-const regexpRegexp = /^\/(.*)\/([gimy]*)$/;
+const regexpRegexp = /^\/(.*)\/([gimsuy]*)$/;
 
 const hankakuAlphaNum = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 const zenkakuAlphaNum =

--- a/test/utils/regexpSpec.ts
+++ b/test/utils/regexpSpec.ts
@@ -176,6 +176,31 @@ The pattern /TypeScript/im has different flag with other patterns.`);
 
             expect(regexp).toBeNull();
         });
+        it("parse regexp with unicode flag", () => {
+            const regexp = parseRegExpString("/\\p{Script=Han}/u");
+            expect(regexp).toBeTruthy();
+
+            expect(regexp!.source).toBe("\\p{Script=Han}");
+            expect(regexp!.unicode).toBe(true);
+        });
+        it("parse regexp with dotAll flag", () => {
+            const regexp = parseRegExpString("/./s");
+            expect(regexp).toBeTruthy();
+
+            expect(regexp!.source).toBe(".");
+            expect(regexp!.dotAll).toBe(true);
+        });
+        it("parse regexp with multiple modern flags", () => {
+            const regexp = parseRegExpString("/pattern/gimsuy");
+            expect(regexp).toBeTruthy();
+
+            expect(regexp!.global).toBe(true);
+            expect(regexp!.ignoreCase).toBe(true);
+            expect(regexp!.multiline).toBe(true);
+            expect(regexp!.sticky).toBe(true);
+            expect(regexp!.unicode).toBe(true);
+            expect(regexp!.dotAll).toBe(true);
+        });
     });
 
     describe("spreadAlphaNum", () => {


### PR DESCRIPTION
## 概要

ES2020までに追加された新しいフラグをregexp.tsの`parseRegExpString()`に追加し、これらを認識できるようにします。

## Summary

- Update `parseRegExpString` to recognize `u` (unicode) and `s` (dotAll) flags
- Previously, flags like `/pattern/us` in YAML config would silently drop `u` and `s` flags
- Add comprehensive tests for modern flag parsing

## Changes

- **`lib/utils/regexp.ts`**: Updated `regexpRegexp` pattern from `/^\/(.*)\/([gimy]*)$/` to `/^\/(.*)\/([gimsuy]*)$/`
- **`test/utils/regexpSpec.ts`**: Added 3 new test cases:
  - Unicode flag (`/\\p{Script=Han}/u`)
  - dotAll flag (`/./s`)
  - Combined modern flags (`/pattern/gimsuy`)

## Testing

All 32 regexp tests pass. The fix ensures users can now use `u` and `s` flags in their YAML rule patterns.