### PR TITLE
refactor(regexp): remove dead flag sort calls in concat() and combine()

### DIFF
--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -18,7 +18,6 @@ export function concat(args: (string | RegExp)[], flags?: string): RegExp {
         if (typeof c === "string") {
             return p + c;
         } else if (c instanceof RegExp) {
-            c.flags.split("").sort();
             const currentFlags = c.flags.split("").sort().join("");
             if (foundRegExp) {
                 if (prevFlags !== currentFlags) {
@@ -44,7 +43,6 @@ export function combine(args: (string | RegExp)[], flags?: string): RegExp {
             if (typeof arg === "string") {
                 return arg;
             } else if (arg instanceof RegExp) {
-                arg.flags.split("").sort();
                 const currentFlags = arg.flags.split("").sort().join("");
                 if (foundRegExp) {
                     if (prevFlags !== currentFlags) {


### PR DESCRIPTION
## Summary

- Remove unused `.sort()` calls in `concat()` and `combine()` functions
- The removed calls were operating on temporary arrays without storing the result
- No behavioral changes, cleanup only

## Changes

- `lib/utils/regexp.ts`: Remove dead code at lines 21 and 47 where `.sort()` was called but result was discarded