### PR TITLE
fix(regexp): don't escape hyphen in escapeSpecialChars (Issue #34)

### DIFF
--- a/lib/utils/regexp.ts
+++ b/lib/utils/regexp.ts
@@ -116,7 +116,7 @@ export function addDefaultFlags(regexp: RegExp) {
 // Note: Node.js v24がターゲット下限になったらRegExp.escape()に置き換えられる
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape
 export function escapeSpecialChars(str: string): string {
-    return str.replace(/[\\*+.?{}()|^$[\]/-]/g, "\\$&");
+    return str.replace(/[\\*+.?{}()|^$[\]/]/g, "\\$&");
 }
 
 export function collectAll(regexp: RegExp, src: string) {

--- a/test/utils/regexpSpec.ts
+++ b/test/utils/regexpSpec.ts
@@ -230,7 +230,19 @@ The pattern /TypeScript/im has different flag with other patterns.`);
         it("replace special characters 2", () => {
             const result = escapeSpecialChars("\\*+.?{}()[]^$-|/");
 
-            expect(result).toBe("\\\\\\*\\+\\.\\?\\{\\}\\(\\)\\[\\]\\^\\$\\-\\|\\/");
+            // In Unicode mode, - is not escaped (only special inside [])
+            // Actual: \\ \ * \ + \ . \ ? \ { \ } \ ( \ ) \ [ \ ] \ ^ \ $ - \ | \ /
+            expect(result).toBe("\\\\\\*\\+\\.\\?\\{\\}\\(\\)\\[\\]\\^\\$-\\|\\/");
+        });
+        it("should not escape hyphen in Unicode mode (Issue #34)", () => {
+            const result = escapeSpecialChars("R-18");
+            expect(result).toBe("R-18");
+            // Verify it works with prh's default gmu flags
+            expect(() => new RegExp(result, "gmu")).not.toThrow();
+        });
+        it("should escape brackets properly", () => {
+            const result = escapeSpecialChars("[A-Z]");
+            expect(result).toBe("\\[A-Z\\]");
         });
     });
 


### PR DESCRIPTION
## 概要

`escapeSpecialChars()`の特殊文字から`-`を削除します。`/[a-z]/`のように正規表現の中なら特殊文字ですが、それ以外はエスケープの必要がありません。またuフラグは必要のないところでエスケープをするとSyntaxErrorが出るようで、それが #34 の原因となっていたようです。

## Summary

- Fix `escapeSpecialChars()` to stop escaping hyphens, which was causing `SyntaxError` in Unicode mode (u flag)
- Hyphen is only special inside character classes in JS regex; escaping it outside with `u` flag is invalid
- Added tests to verify hyphen works correctly with prh's default `gmu` flags

## Related Issue

Fixes #34

## Changes
- `lib/utils/regexp.ts`: Removed `-` from escape character class in `escapeSpecialChars()`
- `test/utils/regexpSpec.ts`: Updated test expectations and added 2 new tests for Issue #34
## Verification
- ✅ All 84 tests pass
- ✅ ESLint clean