### PR TITLE
feat: generate JSON Schema from prh config types

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ see prh/rules collection https://github.com/prh/rules
 実用上は `git submodule add https://github.com/prh/rules.git prh-rules` して好きなルールを使います。
 これを参照するprh.ymlは次のように書きます。
 
-```prh.yml
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prh/prh/master/prh.schema.json
 version: 1
 
 imports:

--- a/lib/raw.ts
+++ b/lib/raw.ts
@@ -1,46 +1,71 @@
 export interface Config {
+    /** 設定ファイル形式のバージョンを指定します。 */
     version: number;
+    /** ルールセットのメタデータを指定します。この値は校正処理には影響しません。 */
+    meta?: { [key: string]: unknown };
+    /** 現在の設定へ統合する別の設定ファイルを指定します。パスは現在の設定ファイルを基準に解決されます。 */
     imports?: string | (string | ImportSpec)[];
+    /** ファイルパスごとに、ファイル内で校正対象とする範囲と除外する範囲を指定します。 */
     targets?: Target[];
+    /** 適用する校正ルールを指定します。文字列を指定すると、その文字列を`expected`に指定したルールとして扱われます。 */
     rules?: (string | Rule)[]; // string | regexp style string or array
 }
 
 export interface ImportSpec {
+    /** 統合する設定ファイルのパスを指定します。パスは現在の設定ファイルを基準に解決されます。 */
     path: string;
+    /** `true`の場合、指定した設定ファイル内の`imports`を処理しません。 */
     disableImports?: boolean;
-    // when string coming, evaluate to { pattern: string; }
-    ignoreRules?: (string | IgnoreRule)[];
+    /** 指定した設定ファイルから読み込まれたルールのうち、統合から除外するルールを指定します。要素に文字列を指定した場合は、同じ文字列を`pattern`に指定したものとして扱われます。 */
+    ignoreRules?: (string | IgnoreRule)[]; // when string coming, evaluate to { pattern: string; }
 }
 
 export interface IgnoreRule {
+    /** 除外するルールを、照合用正規表現を表す文字列で指定します。たとえば、`pattern: テストB`のルールを除外する場合は`/テストB/gmu`を指定します。 */
     pattern?: string;
+    /** 除外するルールを、校正後に期待する文字列で指定します。 */
     expected?: string;
 }
 
 export interface Target {
+    /** 校正範囲の設定を適用するファイルパスに一致する文字列または正規表現形式の文字列を指定します。 */
     file: string; // string | regexp style string
+    /** ファイル内で校正対象とする範囲を指定します。複数指定した場合は、いずれかに一致する範囲が対象になります。 */
     includes?: (string | TargetPattern)[];
+    /** ファイル内で校正対象から除外する範囲を指定します。`includes`と`excludes`の両方に一致する範囲は除外されます。 */
     excludes?: (string | TargetPattern)[];
 }
 
 export interface TargetPattern {
+    /** ファイル内の範囲に一致する文字列または正規表現形式の文字列を指定します。 */
     pattern: string; // string | regexp style string
 }
 
 export interface Rule {
+    /** 校正後に期待する文字列を指定します。 */
     expected: string;
+    /** 修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。省略すると`expected`からパターンを生成します。 */
     pattern?: string | string[] | null; // string | regexp style string or array
+    /** 修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。`pattern`の別名であり、両方を指定すると`pattern`が優先されます。両方を省略すると`expected`からパターンを生成します。 */
     patterns?: string | string[] | null; // string | regexp style string or array
+    /** `pattern`のキャプチャグループが空であることをルールの適用条件として指定します。対象のグループは`$1`の形式で指定します。 */
     regexpMustEmpty?: string;
+    /** ルールの照合に使用するオプションを指定します。 */
     options?: Options;
+    /** ルールの変換結果を検証するテストケースを指定します。期待と異なる場合は設定ファイルの読み込みに失敗します。 */
     specs?: RuleSpec[];
+    /** 外部ツール向けの補足メッセージを指定します。この値はprh本体の校正処理には影響しません。 */
+    prh?: string;
 }
 
 export interface Options {
+    /** `true`の場合、照合用の正規表現の前後に単語境界（`\b`）を追加します。 */
     wordBoundary?: boolean;
 }
 
 export interface RuleSpec {
+    /** ルールのテストに使用する入力文字列を指定します。 */
     from: string;
+    /** 入力文字列にルールを適用した結果として期待する文字列を指定します。 */
     to: string;
 }

--- a/misc/prh.yml
+++ b/misc/prh.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prh/prh/master/prh.schema.json
 version: 1
 
 # 本ファイルは設定の仕方の見本であり、実用的な校正ルールではありません。
@@ -9,7 +10,7 @@ version: 1
 # リポジトリの設定 git submodule add https://github.com/prh/rules.git prh-rules
 
 # 別の設定ファイルを読み込み、mergeすることもできます。
-imports:
+imports: []
   # - ./prh-rules/media/techbooster.yml
   # - ./prh-rules/files/markdown.yml
   # - ./prh-rules/files/review.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-config-prettier": "^10.1.8",
         "glob": "^13.0.5",
         "prettier": "^3.0.0",
+        "ts-json-schema-generator": "^2.9.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.0.0",
         "vitest": "^4.0.18"
@@ -998,23 +999,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1262,6 +1246,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -1552,19 +1560,25 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -1946,6 +1960,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2170,6 +2194,16 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -2294,13 +2328,49 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-json-schema-generator": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.9.0.tgz",
+      "integrity": "sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "commander": "^14.0.3",
+        "glob": "^13.0.6",
+        "json5": "^2.2.3",
+        "normalize-path": "^3.0.0",
+        "safe-stable-stringify": "^2.5.0",
+        "tslib": "^2.8.1",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "ts-json-schema-generator": "bin/ts-json-schema-generator.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "npm run generate-schema && tsc",
+    "generate-schema": "ts-json-schema-generator --path lib/raw.ts --type Config --out prh.schema.json",
     "lint": "eslint lib/ test/",
     "format": "prettier --write 'lib/**/*.ts' 'test/**/*.ts'",
     "test": "npm run build && vitest run",
@@ -43,6 +44,7 @@
     "eslint-config-prettier": "^10.1.8",
     "glob": "^13.0.5",
     "prettier": "^3.0.0",
+    "ts-json-schema-generator": "^2.9.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.0.0",
     "vitest": "^4.0.18"

--- a/prh.schema.json
+++ b/prh.schema.json
@@ -1,0 +1,259 @@
+{
+  "$ref": "#/definitions/Config",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Config": {
+      "additionalProperties": false,
+      "properties": {
+        "imports": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/ImportSpec"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          ],
+          "description": "現在の設定へ統合する別の設定ファイルを指定します。パスは現在の設定ファイルを基準に解決されます。"
+        },
+        "meta": {
+          "additionalProperties": {},
+          "description": "ルールセットのメタデータを指定します。この値は校正処理には影響しません。",
+          "type": "object"
+        },
+        "rules": {
+          "description": "適用する校正ルールを指定します。文字列を指定すると、その文字列を`expected`に指定したルールとして扱われます。",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/Rule"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "targets": {
+          "description": "ファイルパスごとに、ファイル内で校正対象とする範囲と除外する範囲を指定します。",
+          "items": {
+            "$ref": "#/definitions/Target"
+          },
+          "type": "array"
+        },
+        "version": {
+          "description": "設定ファイル形式のバージョンを指定します。",
+          "type": "number"
+        }
+      },
+      "required": [
+        "version"
+      ],
+      "type": "object"
+    },
+    "IgnoreRule": {
+      "additionalProperties": false,
+      "properties": {
+        "expected": {
+          "description": "除外するルールを、校正後に期待する文字列で指定します。",
+          "type": "string"
+        },
+        "pattern": {
+          "description": "除外するルールを、照合用正規表現を表す文字列で指定します。たとえば、`pattern: テストB`のルールを除外する場合は`/テストB/gmu`を指定します。",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ImportSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "disableImports": {
+          "description": "`true`の場合、指定した設定ファイル内の`imports`を処理しません。",
+          "type": "boolean"
+        },
+        "ignoreRules": {
+          "description": "指定した設定ファイルから読み込まれたルールのうち、統合から除外するルールを指定します。要素に文字列を指定した場合は、同じ文字列を`pattern`に指定したものとして扱われます。",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/IgnoreRule"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "path": {
+          "description": "統合する設定ファイルのパスを指定します。パスは現在の設定ファイルを基準に解決されます。",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "Options": {
+      "additionalProperties": false,
+      "properties": {
+        "wordBoundary": {
+          "description": "`true`の場合、照合用の正規表現の前後に単語境界（`\\b`）を追加します。",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Rule": {
+      "additionalProperties": false,
+      "properties": {
+        "expected": {
+          "description": "校正後に期待する文字列を指定します。",
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/Options",
+          "description": "ルールの照合に使用するオプションを指定します。"
+        },
+        "pattern": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。省略すると`expected`からパターンを生成します。"
+        },
+        "patterns": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。`pattern`の別名であり、両方を指定すると`pattern`が優先されます。両方を省略すると`expected`からパターンを生成します。"
+        },
+        "prh": {
+          "description": "外部ツール向けの補足メッセージを指定します。この値はprh本体の校正処理には影響しません。",
+          "type": "string"
+        },
+        "regexpMustEmpty": {
+          "description": "`pattern`のキャプチャグループが空であることをルールの適用条件として指定します。対象のグループは`$1`の形式で指定します。",
+          "type": "string"
+        },
+        "specs": {
+          "description": "ルールの変換結果を検証するテストケースを指定します。期待と異なる場合は設定ファイルの読み込みに失敗します。",
+          "items": {
+            "$ref": "#/definitions/RuleSpec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "expected"
+      ],
+      "type": "object"
+    },
+    "RuleSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "description": "ルールのテストに使用する入力文字列を指定します。",
+          "type": "string"
+        },
+        "to": {
+          "description": "入力文字列にルールを適用した結果として期待する文字列を指定します。",
+          "type": "string"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "type": "object"
+    },
+    "Target": {
+      "additionalProperties": false,
+      "properties": {
+        "excludes": {
+          "description": "ファイル内で校正対象から除外する範囲を指定します。`includes`と`excludes`の両方に一致する範囲は除外されます。",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/TargetPattern"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "file": {
+          "description": "校正範囲の設定を適用するファイルパスに一致する文字列または正規表現形式の文字列を指定します。",
+          "type": "string"
+        },
+        "includes": {
+          "description": "ファイル内で校正対象とする範囲を指定します。複数指定した場合は、いずれかに一致する範囲が対象になります。",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/TargetPattern"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "file"
+      ],
+      "type": "object"
+    },
+    "TargetPattern": {
+      "additionalProperties": false,
+      "properties": {
+        "pattern": {
+          "description": "ファイル内の範囲に一致する文字列または正規表現形式の文字列を指定します。",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pattern"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
prhの設定ファイル向けJSON Schemaを追加します。

これにより、YAML Language Serverに対応するエディタでは、YAMLファイルの先頭にmodelineを追加することで、設定項目の補完、説明の表示、入力内容の検証が利用可能になります。

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/prh/prh/master/prh.schema.json
```

Schema定義は実装との乖離を防ぐため、既存のTypeScriptの型定義とTSDocから[`ts-json-schema-generator`](https://www.npmjs.com/package/ts-json-schema-generator)を使用して生成します。
