### PR TITLE
feat(schema): add examples, $id and markdownDescription

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,6 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run build
+      # lib/raw.ts の変更が prh.schema.json に反映済みか確認する
+      - run: git diff --exit-code prh.schema.json
       - run: npm test

--- a/lib/raw.ts
+++ b/lib/raw.ts
@@ -1,71 +1,150 @@
 export interface Config {
-    /** 設定ファイル形式のバージョンを指定します。 */
+    /**
+     * 設定ファイル形式のバージョンを指定します。
+     * @example 1
+     */
     version: number;
     /** ルールセットのメタデータを指定します。この値は校正処理には影響しません。 */
-    meta?: { [key: string]: unknown };
-    /** 現在の設定へ統合する別の設定ファイルを指定します。パスは現在の設定ファイルを基準に解決されます。 */
+    meta?: { [key: string]: unknown }; // NOTE prh本体は参照しない 設定ファイルの仕様として定義している
+    /**
+     * 現在の設定へ統合する別の設定ファイルを指定します。パスは現在の設定ファイルを基準に解決されます。
+     * @example "./prh-rules/media/techbooster.yml"
+     * @example ["./prh-rules/media/techbooster.yml", "./prh-rules/files/markdown.yml"]
+     * @example [{ "path": "./prh-rules/media/techbooster.yml", "ignoreRules": ["/テストB/gmu"] }]
+     */
     imports?: string | (string | ImportSpec)[];
-    /** ファイルパスごとに、ファイル内で校正対象とする範囲と除外する範囲を指定します。 */
+    /**
+     * ファイルパスごとに、ファイル内で校正対象とする範囲と除外する範囲を指定します。
+     * @example [{ "file": "/\\.md$/", "excludes": ["/`.*?`/"] }]
+     */
     targets?: Target[];
-    /** 適用する校正ルールを指定します。文字列を指定すると、その文字列を`expected`に指定したルールとして扱われます。 */
+    /**
+     * 適用する校正ルールを指定します。文字列を指定すると、その文字列を`expected`に指定したルールとして扱われます。
+     * @example ["Cookie", { "expected": "デフォルト", "pattern": "ディフォルト" }]
+     */
     rules?: (string | Rule)[]; // string | regexp style string or array
 }
 
 export interface ImportSpec {
-    /** 統合する設定ファイルのパスを指定します。パスは現在の設定ファイルを基準に解決されます。 */
+    /**
+     * 統合する設定ファイルのパスを指定します。パスは現在の設定ファイルを基準に解決されます。
+     * @example "./prh-rules/media/techbooster.yml"
+     */
     path: string;
-    /** `true`の場合、指定した設定ファイル内の`imports`を処理しません。 */
+    /**
+     * `true`の場合、指定した設定ファイル内の`imports`を処理しません。
+     * @default false
+     */
     disableImports?: boolean;
-    /** 指定した設定ファイルから読み込まれたルールのうち、統合から除外するルールを指定します。要素に文字列を指定した場合は、同じ文字列を`pattern`に指定したものとして扱われます。 */
+    /**
+     * 指定した設定ファイルから読み込まれたルールのうち、統合から除外するルールを指定します。要素に文字列を指定した場合は、同じ文字列を`pattern`に指定したものとして扱われます。
+     * @example ["/テストB/gmu"]
+     * @example [{ "expected": "テストA" }]
+     */
     ignoreRules?: (string | IgnoreRule)[]; // when string coming, evaluate to { pattern: string; }
 }
 
 export interface IgnoreRule {
-    /** 除外するルールを、照合用正規表現を表す文字列で指定します。たとえば、`pattern: テストB`のルールを除外する場合は`/テストB/gmu`を指定します。 */
+    /**
+     * 除外するルールを、照合用正規表現を表す文字列で指定します。たとえば、`pattern: テストB`のルールを除外する場合は`/テストB/gmu`を指定します。
+     * `pattern`を省略したルールでは`expected`から生成された正規表現になるため、`prh --rules-yaml`の出力で実際の値を確認してください。
+     * @example "/テストB/gmu"
+     */
     pattern?: string;
-    /** 除外するルールを、校正後に期待する文字列で指定します。 */
+    /**
+     * 除外するルールを、校正後に期待する文字列で指定します。
+     * @example "テストA"
+     */
     expected?: string;
 }
 
 export interface Target {
-    /** 校正範囲の設定を適用するファイルパスに一致する文字列または正規表現形式の文字列を指定します。 */
+    /**
+     * 校正範囲の設定を適用するファイルパスに一致する文字列または正規表現形式の文字列を指定します。
+     * @example "/\\.md$/"
+     * @example "/\\.re$/"
+     */
     file: string; // string | regexp style string
-    /** ファイル内で校正対象とする範囲を指定します。複数指定した場合は、いずれかに一致する範囲が対象になります。 */
+    /**
+     * ファイル内で校正対象とする範囲を指定します。複数指定した場合は、いずれかに一致する範囲が対象になります。
+     * @example ["/\\/\\/.*$/"]
+     */
     includes?: (string | TargetPattern)[];
-    /** ファイル内で校正対象から除外する範囲を指定します。`includes`と`excludes`の両方に一致する範囲は除外されます。 */
+    /**
+     * ファイル内で校正対象から除外する範囲を指定します。`includes`と`excludes`の両方に一致する範囲は除外されます。
+     * @example ["/`.*?`/", "/\\[[^\\]]*\\]\\([^)]+\\)/"]
+     * @example [{ "pattern": "/^#@.*$/" }]
+     */
     excludes?: (string | TargetPattern)[];
 }
 
 export interface TargetPattern {
-    /** ファイル内の範囲に一致する文字列または正規表現形式の文字列を指定します。 */
+    /**
+     * ファイル内の範囲に一致する文字列または正規表現形式の文字列を指定します。
+     * @example "/^#@.*$/"
+     */
     pattern: string; // string | regexp style string
 }
 
 export interface Rule {
-    /** 校正後に期待する文字列を指定します。 */
+    /**
+     * 校正後に期待する文字列を指定します。`pattern`のキャプチャグループを`$1`の形式で参照できます。
+     * @example "ソフトウェア"
+     * @example "（$1）"
+     */
     expected: string;
-    /** 修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。省略すると`expected`からパターンを生成します。 */
+    /**
+     * 修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。
+     * `pattern`と`patterns`のどちらも省略した場合は`expected`からパターンを生成します。
+     * @example "ディフォルト"
+     * @example "/サーバ(?!ー)/"
+     * @example ["ハードウエアー", "ハードウェアー", "ハードウエア"]
+     */
     pattern?: string | string[] | null; // string | regexp style string or array
-    /** 修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。`pattern`の別名であり、両方を指定すると`pattern`が優先されます。両方を省略すると`expected`からパターンを生成します。 */
+    /**
+     * 修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。`pattern`の別名であり、両方を指定すると`pattern`が優先されます。両方を省略すると`expected`からパターンを生成します。
+     * @example ["ハードウエアー", "ハードウェアー", "ハードウエア"]
+     */
     patterns?: string | string[] | null; // string | regexp style string or array
-    /** `pattern`のキャプチャグループが空であることをルールの適用条件として指定します。対象のグループは`$1`の形式で指定します。 */
+    /**
+     * `pattern`のキャプチャグループが空であることをルールの適用条件として指定します。対象のグループは`$1`の形式で指定します。
+     * @example "$1"
+     */
     regexpMustEmpty?: string;
-    /** ルールの照合に使用するオプションを指定します。 */
+    /**
+     * ルールの照合に使用するオプションを指定します。
+     * @example { "wordBoundary": true }
+     */
     options?: Options;
-    /** ルールの変換結果を検証するテストケースを指定します。期待と異なる場合は設定ファイルの読み込みに失敗します。 */
+    /**
+     * ルールの変換結果を検証するテストケースを指定します。期待と異なる場合は設定ファイルの読み込みに失敗します。
+     * @example [{ "from": "jquery", "to": "jQuery" }, { "from": "ＪＱＵＥＲＹ", "to": "jQuery" }]
+     */
     specs?: RuleSpec[];
-    /** 外部ツール向けの補足メッセージを指定します。この値はprh本体の校正処理には影響しません。 */
-    prh?: string;
+    /**
+     * 外部ツール向けの補足メッセージを指定します。この値はprh本体の校正処理には影響しません。
+     * @example "半角カッコの代わりに全角カッコを使うこと。文字のバランスが崩れるためです"
+     */
+    prh?: string; // NOTE prh本体は参照しない Rule#raw 経由で外部ツールが参照する
 }
 
 export interface Options {
-    /** `true`の場合、照合用の正規表現の前後に単語境界（`\b`）を追加します。 */
+    /**
+     * `true`の場合、照合用の正規表現の前後に単語境界（`\b`）を追加します。
+     * @default false
+     */
     wordBoundary?: boolean;
 }
 
 export interface RuleSpec {
-    /** ルールのテストに使用する入力文字列を指定します。 */
+    /**
+     * ルールのテストに使用する入力文字列を指定します。
+     * @example "ＪＱＵＥＲＹ"
+     */
     from: string;
-    /** 入力文字列にルールを適用した結果として期待する文字列を指定します。 */
+    /**
+     * 入力文字列にルールを適用した結果として期待する文字列を指定します。
+     * @example "jQuery"
+     */
     to: string;
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "npm run generate-schema && tsc",
-    "generate-schema": "ts-json-schema-generator --path lib/raw.ts --type Config --out prh.schema.json",
+    "generate-schema": "ts-json-schema-generator --path lib/raw.ts --type Config --id https://raw.githubusercontent.com/prh/prh/master/prh.schema.json --markdown-description --out prh.schema.json",
     "lint": "eslint lib/ test/",
     "format": "prettier --write 'lib/**/*.ts' 'test/**/*.ts'",
     "test": "npm run build && vitest run",

--- a/prh.schema.json
+++ b/prh.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://raw.githubusercontent.com/prh/prh/master/prh.schema.json",
   "$ref": "#/definitions/Config",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
@@ -24,15 +25,41 @@
               "type": "array"
             }
           ],
-          "description": "現在の設定へ統合する別の設定ファイルを指定します。パスは現在の設定ファイルを基準に解決されます。"
+          "description": "現在の設定へ統合する別の設定ファイルを指定します。パスは現在の設定ファイルを基準に解決されます。",
+          "examples": [
+            "./prh-rules/media/techbooster.yml",
+            [
+              "./prh-rules/media/techbooster.yml",
+              "./prh-rules/files/markdown.yml"
+            ],
+            [
+              {
+                "ignoreRules": [
+                  "/テストB/gmu"
+                ],
+                "path": "./prh-rules/media/techbooster.yml"
+              }
+            ]
+          ],
+          "markdownDescription": "現在の設定へ統合する別の設定ファイルを指定します。パスは現在の設定ファイルを基準に解決されます。"
         },
         "meta": {
           "additionalProperties": {},
           "description": "ルールセットのメタデータを指定します。この値は校正処理には影響しません。",
+          "markdownDescription": "ルールセットのメタデータを指定します。この値は校正処理には影響しません。",
           "type": "object"
         },
         "rules": {
           "description": "適用する校正ルールを指定します。文字列を指定すると、その文字列を`expected`に指定したルールとして扱われます。",
+          "examples": [
+            [
+              "Cookie",
+              {
+                "expected": "デフォルト",
+                "pattern": "ディフォルト"
+              }
+            ]
+          ],
           "items": {
             "anyOf": [
               {
@@ -43,17 +70,33 @@
               }
             ]
           },
+          "markdownDescription": "適用する校正ルールを指定します。文字列を指定すると、その文字列を`expected`に指定したルールとして扱われます。",
           "type": "array"
         },
         "targets": {
           "description": "ファイルパスごとに、ファイル内で校正対象とする範囲と除外する範囲を指定します。",
+          "examples": [
+            [
+              {
+                "excludes": [
+                  "/`.*?`/"
+                ],
+                "file": "/\\.md$/"
+              }
+            ]
+          ],
           "items": {
             "$ref": "#/definitions/Target"
           },
+          "markdownDescription": "ファイルパスごとに、ファイル内で校正対象とする範囲と除外する範囲を指定します。",
           "type": "array"
         },
         "version": {
           "description": "設定ファイル形式のバージョンを指定します。",
+          "examples": [
+            1
+          ],
+          "markdownDescription": "設定ファイル形式のバージョンを指定します。",
           "type": "number"
         }
       },
@@ -67,10 +110,18 @@
       "properties": {
         "expected": {
           "description": "除外するルールを、校正後に期待する文字列で指定します。",
+          "examples": [
+            "テストA"
+          ],
+          "markdownDescription": "除外するルールを、校正後に期待する文字列で指定します。",
           "type": "string"
         },
         "pattern": {
-          "description": "除外するルールを、照合用正規表現を表す文字列で指定します。たとえば、`pattern: テストB`のルールを除外する場合は`/テストB/gmu`を指定します。",
+          "description": "除外するルールを、照合用正規表現を表す文字列で指定します。たとえば、`pattern: テストB`のルールを除外する場合は`/テストB/gmu`を指定します。 `pattern`を省略したルールでは`expected`から生成された正規表現になるため、`prh --rules-yaml`の出力で実際の値を確認してください。",
+          "examples": [
+            "/テストB/gmu"
+          ],
+          "markdownDescription": "除外するルールを、照合用正規表現を表す文字列で指定します。たとえば、`pattern: テストB`のルールを除外する場合は`/テストB/gmu`を指定します。\n`pattern`を省略したルールでは`expected`から生成された正規表現になるため、`prh --rules-yaml`の出力で実際の値を確認してください。",
           "type": "string"
         }
       },
@@ -80,11 +131,23 @@
       "additionalProperties": false,
       "properties": {
         "disableImports": {
+          "default": false,
           "description": "`true`の場合、指定した設定ファイル内の`imports`を処理しません。",
+          "markdownDescription": "`true`の場合、指定した設定ファイル内の`imports`を処理しません。",
           "type": "boolean"
         },
         "ignoreRules": {
           "description": "指定した設定ファイルから読み込まれたルールのうち、統合から除外するルールを指定します。要素に文字列を指定した場合は、同じ文字列を`pattern`に指定したものとして扱われます。",
+          "examples": [
+            [
+              "/テストB/gmu"
+            ],
+            [
+              {
+                "expected": "テストA"
+              }
+            ]
+          ],
           "items": {
             "anyOf": [
               {
@@ -95,10 +158,15 @@
               }
             ]
           },
+          "markdownDescription": "指定した設定ファイルから読み込まれたルールのうち、統合から除外するルールを指定します。要素に文字列を指定した場合は、同じ文字列を`pattern`に指定したものとして扱われます。",
           "type": "array"
         },
         "path": {
           "description": "統合する設定ファイルのパスを指定します。パスは現在の設定ファイルを基準に解決されます。",
+          "examples": [
+            "./prh-rules/media/techbooster.yml"
+          ],
+          "markdownDescription": "統合する設定ファイルのパスを指定します。パスは現在の設定ファイルを基準に解決されます。",
           "type": "string"
         }
       },
@@ -111,7 +179,9 @@
       "additionalProperties": false,
       "properties": {
         "wordBoundary": {
+          "default": false,
           "description": "`true`の場合、照合用の正規表現の前後に単語境界（`\\b`）を追加します。",
+          "markdownDescription": "`true`の場合、照合用の正規表現の前後に単語境界（`\\b`）を追加します。",
           "type": "boolean"
         }
       },
@@ -121,12 +191,23 @@
       "additionalProperties": false,
       "properties": {
         "expected": {
-          "description": "校正後に期待する文字列を指定します。",
+          "description": "校正後に期待する文字列を指定します。`pattern`のキャプチャグループを`$1`の形式で参照できます。",
+          "examples": [
+            "ソフトウェア",
+            "（$1）"
+          ],
+          "markdownDescription": "校正後に期待する文字列を指定します。`pattern`のキャプチャグループを`$1`の形式で参照できます。",
           "type": "string"
         },
         "options": {
           "$ref": "#/definitions/Options",
-          "description": "ルールの照合に使用するオプションを指定します。"
+          "description": "ルールの照合に使用するオプションを指定します。",
+          "examples": [
+            {
+              "wordBoundary": true
+            }
+          ],
+          "markdownDescription": "ルールの照合に使用するオプションを指定します。"
         },
         "pattern": {
           "anyOf": [
@@ -143,7 +224,17 @@
               "type": "null"
             }
           ],
-          "description": "修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。省略すると`expected`からパターンを生成します。"
+          "description": "修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。 `pattern`と`patterns`のどちらも省略した場合は`expected`からパターンを生成します。",
+          "examples": [
+            "ディフォルト",
+            "/サーバ(?!ー)/",
+            [
+              "ハードウエアー",
+              "ハードウェアー",
+              "ハードウエア"
+            ]
+          ],
+          "markdownDescription": "修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。\n`pattern`と`patterns`のどちらも省略した場合は`expected`からパターンを生成します。"
         },
         "patterns": {
           "anyOf": [
@@ -160,21 +251,50 @@
               "type": "null"
             }
           ],
-          "description": "修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。`pattern`の別名であり、両方を指定すると`pattern`が優先されます。両方を省略すると`expected`からパターンを生成します。"
+          "description": "修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。`pattern`の別名であり、両方を指定すると`pattern`が優先されます。両方を省略すると`expected`からパターンを生成します。",
+          "examples": [
+            [
+              "ハードウエアー",
+              "ハードウェアー",
+              "ハードウエア"
+            ]
+          ],
+          "markdownDescription": "修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。`pattern`の別名であり、両方を指定すると`pattern`が優先されます。両方を省略すると`expected`からパターンを生成します。"
         },
         "prh": {
           "description": "外部ツール向けの補足メッセージを指定します。この値はprh本体の校正処理には影響しません。",
+          "examples": [
+            "半角カッコの代わりに全角カッコを使うこと。文字のバランスが崩れるためです"
+          ],
+          "markdownDescription": "外部ツール向けの補足メッセージを指定します。この値はprh本体の校正処理には影響しません。",
           "type": "string"
         },
         "regexpMustEmpty": {
           "description": "`pattern`のキャプチャグループが空であることをルールの適用条件として指定します。対象のグループは`$1`の形式で指定します。",
+          "examples": [
+            "$1"
+          ],
+          "markdownDescription": "`pattern`のキャプチャグループが空であることをルールの適用条件として指定します。対象のグループは`$1`の形式で指定します。",
           "type": "string"
         },
         "specs": {
           "description": "ルールの変換結果を検証するテストケースを指定します。期待と異なる場合は設定ファイルの読み込みに失敗します。",
+          "examples": [
+            [
+              {
+                "from": "jquery",
+                "to": "jQuery"
+              },
+              {
+                "from": "ＪＱＵＥＲＹ",
+                "to": "jQuery"
+              }
+            ]
+          ],
           "items": {
             "$ref": "#/definitions/RuleSpec"
           },
+          "markdownDescription": "ルールの変換結果を検証するテストケースを指定します。期待と異なる場合は設定ファイルの読み込みに失敗します。",
           "type": "array"
         }
       },
@@ -188,10 +308,18 @@
       "properties": {
         "from": {
           "description": "ルールのテストに使用する入力文字列を指定します。",
+          "examples": [
+            "ＪＱＵＥＲＹ"
+          ],
+          "markdownDescription": "ルールのテストに使用する入力文字列を指定します。",
           "type": "string"
         },
         "to": {
           "description": "入力文字列にルールを適用した結果として期待する文字列を指定します。",
+          "examples": [
+            "jQuery"
+          ],
+          "markdownDescription": "入力文字列にルールを適用した結果として期待する文字列を指定します。",
           "type": "string"
         }
       },
@@ -206,6 +334,17 @@
       "properties": {
         "excludes": {
           "description": "ファイル内で校正対象から除外する範囲を指定します。`includes`と`excludes`の両方に一致する範囲は除外されます。",
+          "examples": [
+            [
+              "/`.*?`/",
+              "/\\[[^\\]]*\\]\\([^)]+\\)/"
+            ],
+            [
+              {
+                "pattern": "/^#@.*$/"
+              }
+            ]
+          ],
           "items": {
             "anyOf": [
               {
@@ -216,14 +355,25 @@
               }
             ]
           },
+          "markdownDescription": "ファイル内で校正対象から除外する範囲を指定します。`includes`と`excludes`の両方に一致する範囲は除外されます。",
           "type": "array"
         },
         "file": {
           "description": "校正範囲の設定を適用するファイルパスに一致する文字列または正規表現形式の文字列を指定します。",
+          "examples": [
+            "/\\.md$/",
+            "/\\.re$/"
+          ],
+          "markdownDescription": "校正範囲の設定を適用するファイルパスに一致する文字列または正規表現形式の文字列を指定します。",
           "type": "string"
         },
         "includes": {
           "description": "ファイル内で校正対象とする範囲を指定します。複数指定した場合は、いずれかに一致する範囲が対象になります。",
+          "examples": [
+            [
+              "/\\/\\/.*$/"
+            ]
+          ],
           "items": {
             "anyOf": [
               {
@@ -234,6 +384,7 @@
               }
             ]
           },
+          "markdownDescription": "ファイル内で校正対象とする範囲を指定します。複数指定した場合は、いずれかに一致する範囲が対象になります。",
           "type": "array"
         }
       },
@@ -247,6 +398,10 @@
       "properties": {
         "pattern": {
           "description": "ファイル内の範囲に一致する文字列または正規表現形式の文字列を指定します。",
+          "examples": [
+            "/^#@.*$/"
+          ],
+          "markdownDescription": "ファイル内の範囲に一致する文字列または正規表現形式の文字列を指定します。",
           "type": "string"
         }
       },


### PR DESCRIPTION
#112 のフォローアップです。生成される JSON Schema を、設定ファイルを書くときのヒントとして機能するように補強します。

## 変更内容

### 1. `--markdown-description` を追加

TSDoc は `` `expected` `` や `` `$1` `` のようにバッククォートを多用していますが、yaml-language-server は `description` をプレーンテキストとして扱うため、ホバーではバッククォートがそのまま表示されていました。`markdownDescription` を併記することでコードスパンとして描画されます（`yamlHover.js` および `yamlCompletion.js` が `markdownDescription` を `description` より優先することを確認済み）。

### 2. `@example` を追加（計29個）

`ts-json-schema-generator` の `@example` は JSON5 としてパースされ `examples` になります。yaml-language-server はこれを `yaml.stringify()` してから ` ```yaml ` フェンスで囲んでホバーに表示し、さらに値の補完候補としても提供します。つまり JSON5 で書いた例が YAML の実例として表示されます。

```ts
/**
 * 修正対象に一致する文字列、正規表現形式の文字列、またはそれらの配列を指定します。
 * `pattern`と`patterns`のどちらも省略した場合は`expected`からパターンを生成します。
 * @example "ディフォルト"
 * @example "/サーバ(?!ー)/"
 * @example ["ハードウエアー", "ハードウェアー", "ハードウエア"]
 */
pattern?: string | string[] | null;
```

例の素材は `misc/prh.yml` と prh/rules の実ファイルから取っています。不定形な `meta` には付けていません。

### 3. `--id` を追加

`$id` として schema の raw URL を埋めます。`$id` を付けると draft-07 では基底 URI が変わるため、トップレベルの `"$ref": "#/definitions/Config"` が壊れないことを ajv で確認しています。

### 4. 説明文の修正

実装と突き合わせた結果、以下が不正確または記述漏れでした。

- **`Rule.pattern`** — 「省略すると`expected`からパターンを生成します」は不正確でした。実装は `rawRule.pattern || rawRule.patterns` なので、`pattern` を省略しても `patterns` があればそちらが使われます
- **`Rule.expected`** — `$1`〜`$99` で `pattern` のキャプチャグループを参照できること（`changeset/diff.ts` の `newText`）が書かれていませんでした。`misc/prh.yml` の `expected: （$1）` にも出てくる主要機能です
- **`IgnoreRule.pattern`** — 例の `/テストB/gmu` は `pattern` を明示したルールでは正しいのですが、`pattern` を省略したルールでは `spreadAlphaNum` 展開後の `/[MmＭｍ]…/gmu` になります。`prh --rules-yaml` で確認する旨を追記しました

### 5. `meta` / `prh` に NOTE コメント

どちらも prh 本体からは一切参照されません（`prh` は `Rule#raw` 経由で外部ツールが読む）。`raw.ts` が「Engine が読む型」から「設定ファイルの schema」へ役割が広がったため、将来デッドコードとして消されないよう行末コメントを添えています。schema には漏れません。

### 6. CI に drift チェック

`npm run build` が `prh.schema.json` を再生成するため、CI は常に生成し直してしまい、コミット済みの schema が古くても検出できませんでした。`lib/raw.ts` だけ変更して schema の再生成を忘れると、`raw.githubusercontent.com/prh/prh/master/prh.schema.json` が静かに stale になります。

```yaml
      - run: npm run build
      # lib/raw.ts の変更が prh.schema.json に反映済みか確認する
      - run: git diff --exit-code prh.schema.json
```

## 確認したこと

- `npm run build` / `vitest run` (84 passed) / `npm run lint` / `prettier --check` すべて通過
- `@example` は JSON5 としてパースできないと黙って捨てられるため、`lib/raw.ts` の 29 個と schema の `examples` 29 個が一致することを確認
- 29 個の例すべてを、それ自身のサブスキーマに対して ajv で検証（不正 0 件）
- 各例を実際に prh に食わせて期待どおり動作することを確認（`/サーバ(?!ー)/`、`（$1）`、`regexpMustEmpty: $1`、`targets` の includes/excludes など）
- CI の drift チェックが両方向で機能することを確認（一致時 exit 0 / `raw.ts` のみ変更した場合 exit 1）
- prh/rules の実ルールファイル 11 件を再検証。検出される NG は `media/WEB+DB_PRESS.yml` の `spec:` → `specs:` タイポ 1 件のみで、これは schema が見つけた既存の実バグです（別途 prh/rules へ PR 予定）

## 対応していないこと

- `misc/prh.yml` の `imports: []`（`imports: null` を schema が拒否する件）はそのままにしています
- `prh.schema.json` の末尾改行なし。機械生成なので一貫性は保たれるため現状維持
- `version` の値域を `1` に絞ることはしていません。複数の値が取れるようになった時点で改善する方針
- SchemaStore への登録と README への modeline の節追加はフォローアップ扱い

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvmyTvCcGd3Rs3X1dxbg9P
